### PR TITLE
Home fix

### DIFF
--- a/FirstAutomatedBld.vbs
+++ b/FirstAutomatedBld.vbs
@@ -128,6 +128,7 @@ WshSysEnv("MSYSTEM") = "MSYS"
 WshSysEnv("WD") = WshShell.CurrentDirectory & "\msys64\usr\bin\"
 mintty_path= WshShell.CurrentDirectory & "\msys64\usr\bin\mintty.exe"
 WshSysEnv("MSYSCON") = "mintty.exe"
+WshSysEnv("HOME") = WshShell.CurrentDirectory & "\msys64\home\" & WshSysEnv("USERNAME") & "\"
 
 Rem ************** Ready to Launch Mintty ***************************************
 cmd1 = "" & mintty_path & "" & " --hold error -i /msys2.ico /usr/bin/bash --login"

--- a/bld_ffmpeg.sh
+++ b/bld_ffmpeg.sh
@@ -17,9 +17,4 @@ git pull -v --progress
   --enable-avisynth --disable-doc --disable-debug \
   --disable-network --disable-shared --disable-w32threads
 make clean
-t_threads=$(nproc)
-forks=$((t_threads-1))
-if [ $forks < 1 ]; then
-forks=1
-fi
-make -j$(forks) && make install
+make -j$(nproc) && make install

--- a/bld_ffmpeg.sh
+++ b/bld_ffmpeg.sh
@@ -17,4 +17,9 @@ git pull -v --progress
   --enable-avisynth --disable-doc --disable-debug \
   --disable-network --disable-shared --disable-w32threads
 make clean
-make -j$(nproc) && make install
+t_threads=$(nproc)
+forks=$((t_threads-1))
+if [ $forks < 1 ]; then
+forks=1
+fi
+make -j$(forks) && make install

--- a/bld_lsw_avs.sh
+++ b/bld_lsw_avs.sh
@@ -29,7 +29,7 @@ msbuild.exe LSMASHSourceVCX.sln /target:Rebuild /p:Configuration=Release;Platfor
 chcp 65001
 EOF
 
-cmd.exe /c bld_lsw_avs.bat
+$COMSPEC /c bld_lsw_avs.bat
 
 cd ~
 if [ -f ~/LSW/AviSynth/Release/LSMASHSource.dll ]; then

--- a/bld_lsw_avs_64.sh
+++ b/bld_lsw_avs_64.sh
@@ -29,7 +29,7 @@ msbuild.exe LSMASHSourceVCX.sln /target:Rebuild /p:Configuration=Release;Platfor
 chcp 65001
 EOF
 
-cmd.exe /c bld_lsw_avs64.bat
+$COMSPEC /c bld_lsw_avs64.bat
 
 cd ~
 if [ -f ~/LSW_64/AviSynth/x64/Release/LSMASHSource.dll ]; then

--- a/inst_base.sh
+++ b/inst_base.sh
@@ -5,7 +5,7 @@ cd /etc/
 echo "Backing up /etc/profile"
 cp ./profile ./profile.original
 echo "Modifying profile"
-sed -i '
+sed '
 /\s*\(MINGW32\))/a \
     ACLOCAL_PATH="/mingw32/share/aclocal:/usr/share/aclocal" \
     CC="gcc" \
@@ -15,24 +15,28 @@ sed -i '
     CFLAGS="-m32" \
     CXXFLAGS="-m32" \
     LDFLAGS="-m32" \
-' < ./profile
+' < ./profile > ./profile1
 
-sed -i '
+sed '
 /\s*\(MINGW64\))/a \
     ACLOCAL_PATH="/mingw64/share/aclocal:/usr/share/aclocal" \
     CC="gcc" \
     CXX="g++" \
     LD="ld" \
     AR="ar" \
-' < ./profile
+' < ./profile1 > ./profile2
 
-sed -i 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:\/c\/Windows\/System32/' < ./profile
+sed 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:\/c\/Windows\/System32/' < ./profile2 > ./profile3
 #HOME fix attempt
 expected_home="/home/$(id -u -n)"
 if [ $HOME != $expected_home ]; then
 HOME=$expected_home
-cat 'HOME='$expected_home >> /etc/profile
+cat 'HOME='$expected_home >> /etc/profile3
 fi
+
+mv profile profile.bak
+mv profile3 profile
+cd ~
 
 
 pacman --needed --noconfirm -S pkg-config libtool make automake autogen autoconf bison scons vim texinfo wget yasm patch nasm dos2unix diffutils unzip zip p7zip tar git rsync

--- a/inst_base.sh
+++ b/inst_base.sh
@@ -30,8 +30,8 @@ sed -i 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/
 #HOME fix attempt
 expected_home="/home/$(id -u -n)"
 if [ $HOME != $expected_home ]; then
-$HOME=$expected_home
-cat '$HOME='$expected_home >> /etc/profile
+HOME=$expected_home
+cat 'HOME='$expected_home >> /etc/profile
 fi
 
 

--- a/inst_base.sh
+++ b/inst_base.sh
@@ -1,5 +1,40 @@
 #!/usr/bin/bash
 
+#Edit profile
+cd /etc/
+echo "Backing up /etc/profile"
+cp ./profile ./profile.original
+echo "Modifying profile"
+sed -i '
+/\s*\(MINGW32\))/a \
+    ACLOCAL_PATH="/mingw32/share/aclocal:/usr/share/aclocal" \
+    CC="gcc" \
+    CXX="g++" \
+    LD="ld" \
+    AR="ar" \
+    CFLAGS="-m32" \
+    CXXFLAGS="-m32" \
+    LDFLAGS="-m32" \
+' < ./profile
+
+sed -i '
+/\s*\(MINGW64\))/a \
+    ACLOCAL_PATH="/mingw64/share/aclocal:/usr/share/aclocal" \
+    CC="gcc" \
+    CXX="g++" \
+    LD="ld" \
+    AR="ar" \
+' < ./profile
+
+sed -i 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:\/c\/Windows\/System32/' < ./profile
+#HOME fix attempt
+expected_home="/home/$(id -u -n)"
+if [ $HOME != $expected_home ]; then
+$HOME=$expected_home
+cat '$HOME='$expected_home >> /etc/profile
+fi
+
+
 pacman --needed --noconfirm -S pkg-config libtool make automake autogen autoconf bison scons vim texinfo wget yasm patch nasm dos2unix diffutils unzip zip p7zip tar git rsync
 
 if [ $? -ne 0 ]; then
@@ -142,37 +177,6 @@ fi
 
 
 
-#Edit profile
-cd /etc/
-echo "Backing up /etc/profile"
-cp ./profile ./profile.original
-echo "Modifying profile"
-sed '
-/\s*\(MINGW32\))/a \
-    ACLOCAL_PATH="/mingw32/share/aclocal:/usr/share/aclocal" \
-    CC="gcc" \
-    CXX="g++" \
-    LD="ld" \
-    AR="ar" \
-    CFLAGS="-m32" \
-    CXXFLAGS="-m32" \
-    LDFLAGS="-m32" \
-	PATH="${MINGW_MOUNT_POINT}/bin:${MSYS2_PATH}" \
-' < ./profile > ./profile_1
-
-sed '
-/\s*\(MINGW64\))/a \
-    ACLOCAL_PATH="/mingw64/share/aclocal:/usr/share/aclocal" \
-    CC="gcc" \
-    CXX="g++" \
-    LD="ld" \
-    AR="ar" \
-' < ./profile_1 > ./profile_2
-
-sed 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:\/c\/Windows\/System32/' < ./profile_2 > ./profile_3
-
-mv ./profile ./profile_backup
-mv ./profile_3 ./profile
 
 
 

--- a/inst_base.sh
+++ b/inst_base.sh
@@ -31,7 +31,7 @@ sed 's/${MINGW_MOUNT_POINT}\/bin:${MSYS2_PATH}:${PATH}/${MINGW_MOUNT_POINT}\/bin
 expected_home="/home/$(id -u -n)"
 if [ $HOME != $expected_home ]; then
 HOME=$expected_home
-cat 'HOME='$expected_home >> /etc/profile3
+echo "HOME=$expected_home" >> /etc/profile3
 fi
 
 mv profile profile.bak


### PR DESCRIPTION
The $HOME issue is fixed with the following approaches:
1. During first launch, VBScript sets the PROCESS's $HOME to _<msys dir>/home/<USERNAME>_, before launching mintty
2. Appended a _HOME=/home/<USERNAME>_ to /etc/profile
